### PR TITLE
Fix format of all_emojis.json

### DIFF
--- a/views/all_emojis.json.jq
+++ b/views/all_emojis.json.jq
@@ -1,26 +1,26 @@
 # Pick up categories and all the subcategories of it, and then pick up the
 # emojis. All English keywords will be added to the line as well.
 
-.categories[] |
-
-  # Collect category + subcategory combos
-  .name as $cat |
-  reduce .subcategories[] as $sub (
-    [];
-    # Build an array of all emojis in this subcategory
-    . + (
-      $sub.emojis | map(
-        {
-          characters: .characters,
-          name: .name,
-          category_name: $cat,
-          subcategory_name: $sub.name,
-          en_keywords: (.keywords.en // []),
-          qualification: .qualification
-        }
+reduce .categories[] as $category (
+  [];
+  . + (
+    # Collect category + subcategory combos
+    $category.name as $cat |
+    reduce $category.subcategories[] as $sub (
+      [];
+      # Build an array of all emojis in this subcategory
+      . + (
+        $sub.emojis | map(
+          {
+            characters: .characters,
+            name: .name,
+            category_name: $cat,
+            subcategory_name: $sub.name,
+            en_keywords: (.keywords.en // []),
+            qualification: .qualification
+          }
+        )
       )
     )
-  ) |
-
-  # Merge into a single array
-  flatten
+  )
+)


### PR DESCRIPTION
Is now a single array of emoji objects instead of a stream of several arrays of emoji objects.

Diff of generated file:

```diff
diff --git a/data/all_emojis.json b/data/all_emojis.json.new
index 8fa2a8b..4e2feea 100644
--- a/data/all_emojis.json
+++ b/data/all_emojis.json.new
@@ -2094,9 +2094,7 @@
       "zzz"
     ],
     "qualification": "fully-qualified"
-  }
-]
-[
+  },
   {
     "characters": "👋",
     "name": "waving hand",
@@ -31572,9 +31570,7 @@
       "print"
     ],
     "qualification": "fully-qualified"
-  }
-]
-[
+  },
   {
     "characters": "🏻",
     "name": "light skin tone",
@@ -31687,9 +31683,7 @@
       "shaven"
     ],
     "qualification": "fully-qualified"
-  }
-]
-[
+  },
   {
     "characters": "🐵",
     "name": "monkey face",
@@ -33389,9 +33383,7 @@
       "wind"
     ],
     "qualification": "fully-qualified"
-  }
-]
-[
+  },
   {
     "characters": "🍇",
     "name": "grapes",
@@ -35104,9 +35096,7 @@
       "cooking"
     ],
     "qualification": "fully-qualified"
-  }
-]
-[
+  },
   {
     "characters": "🌍",
     "name": "globe showing Europe-Africa",
@@ -38276,9 +38266,7 @@
       "wave"
     ],
     "qualification": "fully-qualified"
-  }
-]
-[
+  },
   {
     "characters": "🎃",
     "name": "jack-o-lantern",
@@ -39508,9 +39496,7 @@
       "twist"
     ],
     "qualification": "fully-qualified"
-  }
-]
-[
+  },
   {
     "characters": "👓",
     "name": "glasses",
@@ -43183,9 +43169,7 @@
       "sign"
     ],
     "qualification": "fully-qualified"
-  }
-]
-[
+  },
   {
     "characters": "🏧",
     "name": "ATM sign",
@@ -46632,9 +46616,7 @@
       "square"
     ],
     "qualification": "fully-qualified"
-  }
-]
-[
+  },
   {
     "characters": "🏁",
     "name": "chequered flag",
```

Fixes #5.